### PR TITLE
accept length != 88

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -307,7 +307,7 @@ _checkDigitValues["Z"] = 35;
  * @author Craig Newton <newtondev@gmail.com>
  */
 function parse (mrz) {
-  if (mrz == null || mrz.length != 88) {
+  if (mrz == null) {
     throw new Error('Invalid MRZ length');
   }
 


### PR DESCRIPTION
The data provided by the an OCR library doesn't always return the correct length, this PR removes the strictness of having a fixed size.
